### PR TITLE
Reads local app data paths from registry and tries program files (both x64 and x86)

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -1184,8 +1184,8 @@ class SideBarOpenInBrowserCommand(sublime_plugin.WindowCommand):
 				commands = ['-a', 'Google Chrome', url]
 			elif sublime.platform() == 'windows':
 				# read local app data path from registry
-				aKey = OpenKey(_winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders") 
-				reg_value, reg_type = _winreg.QueryValueEx (hKey, "Local AppData")
+				aKey = _winreg.OpenKey(_winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders") 
+				reg_value, reg_type = _winreg.QueryValueEx (aKey, "Local AppData")
 
 				items = [
 					  reg_value+'\\Chrome\\Application\\chrome.exe'
@@ -1207,8 +1207,8 @@ class SideBarOpenInBrowserCommand(sublime_plugin.WindowCommand):
 				commands = ['-a', 'Chromium', url]
 			elif sublime.platform() == 'windows':
 				# read local app data path from registry
-				aKey = OpenKey(_winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders") 
-				reg_value, reg_type = _winreg.QueryValueEx (hKey, "Local AppData")
+				aKey = _winreg.OpenKey(_winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders") 
+				reg_value, reg_type = _winreg.QueryValueEx (aKey, "Local AppData")
 
 				items = [
 					  reg_value+'\\Chromium\\Application\\chromium.exe'

--- a/SideBar.py
+++ b/SideBar.py
@@ -10,6 +10,10 @@ from sidebar.SideBarProject import SideBarProject
 
 from send2trash import send2trash
 
+# needed for getting local app data path on windows
+if sublime.platform() == 'windows':
+	import _winreg
+
 def disable_default():
 	default = sublime.packages_path()+'/Default/Side Bar.sublime-menu'
 	desired = sublime.packages_path()+'/SideBarEnhancements/disable_default/Side Bar.sublime-menu.txt'
@@ -1178,32 +1182,45 @@ class SideBarOpenInBrowserCommand(sublime_plugin.WindowCommand):
 			if sublime.platform() == 'osx':
 				items = ['open']
 				commands = ['-a', 'Google Chrome', url]
-			else:
+			elif sublime.platform() == 'windows':
+				# read local app data path from registry
+				aKey = OpenKey(_winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders") 
+				reg_value, reg_type = _winreg.QueryValueEx (hKey, "Local AppData")
+
 				items = [
-					'/usr/bin/google-chrome'
-
-					,'%HOMEPATH%\\Local Settings\\Application Data\\Google\\Chrome\\Application\\chrome.exe'
-					,'%USERPROFILE%\\Configuración local\\Datos de programa\\Google\\Chrome\\Application\\chrome.exe'
-					,'C:\\Users\\%USERNAME%\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe'
-
-					,'chrome'
+					  reg_value+'\\Chrome\\Application\\chrome.exe'
+					,'%PROGRAMFILES%\\Google\\Chrome\\Application\\chrome.exe'
+					,'%PROGRAMFILES(X86)%\\Google\\Chrome\\Application\\chrome.exe'
 					,'chrome.exe'
 				]
 				commands = ['-new-tab', url]
+			else:
+				items = [
+					'/usr/bin/google-chrome'
+					,'chrome'
+				]
+				commands = ['-new-tab', url]
+
 		elif browser == 'chromium':
 			if sublime.platform() == 'osx':
 				items = ['open']
 				commands = ['-a', 'Chromium', url]
+			elif sublime.platform() == 'windows':
+				# read local app data path from registry
+				aKey = OpenKey(_winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders") 
+				reg_value, reg_type = _winreg.QueryValueEx (hKey, "Local AppData")
+
+				items = [
+					  reg_value+'\\Chromium\\Application\\chromium.exe'
+					,'%PROGRAMFILES%\\Chromium\\Application\\chromium.exe'
+					,'%PROGRAMFILES(X86)%\\Chromium\\Application\\chromium.exe'
+					,'chromium.exe'
+				]
+				commands = ['-new-tab', url]
 			else:
 				items = [
 					'/usr/bin/chromium'
-
-					,'%HOMEPATH%\\Local Settings\\Application Data\\Chromium\\Application\\chrome.exe'
-					,'%USERPROFILE%\\Configuración local\\Datos de programa\\Chromium\\Application\\chrome.exe'
-					,'C:\\Users\\%USERNAME%\\AppData\\Local\\Chromium\\Application\\chrome.exe'
-
 					,'chromium'
-					,'chromium.exe'
 				]
 				commands = ['-new-tab', url]
 		elif browser == 'firefox':


### PR DESCRIPTION
Reads paths for Chrome and Chromium from registry instead of having to write localized paths for any possible language. Paths on Win XP is localized, while standarized on Win Vista/7/8. Reading from the registry will always return correct path. 
