### PR TITLE
Remove collisions with Sublime2's built-in shortcuts

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,13 +1,6 @@
 [
-	{ "keys": ["ctrl+t"], "command": "side_bar_new_file2" },
-	{ "keys": ["f12"],
-		"command": "side_bar_open_in_browser" ,
-    "args":{"paths":[], "type":"testing"}
-  },
-	{ "keys": ["alt+f12"],
-		"command": "side_bar_open_in_browser",
-		"args":{"paths":[], "type":"production"}
-	},
-	{ "keys": ["f2"], "command": "side_bar_rename" },
+	{ "keys": ["f12"], "command": "side_bar_open_in_browser", "args": { "paths": [], "type":"testing" } },
+	{ "keys": ["alt+f12"], "command": "side_bar_open_in_browser", "args": { "paths": [], "type":"production" } },
+
 	{ "keys": ["ctrl+alt+f"], "command": "side_bar_find_files_path_containing" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,13 +1,6 @@
 [
-	{ "keys": ["ctrl+t"], "command": "side_bar_new_file2" },
-	{ "keys": ["f12"],
-		"command": "side_bar_open_in_browser" ,
-    "args":{"paths":[], "type":"testing"}
-  },
-	{ "keys": ["alt+f12"],
-		"command": "side_bar_open_in_browser",
-		"args":{"paths":[], "type":"production"}
-	},
-	{ "keys": ["f2"], "command": "side_bar_rename" },
+	{ "keys": ["f12"], "command": "side_bar_open_in_browser", "args": { "paths": [], "type":"testing" } },
+
+	{ "keys": ["alt+f12"], "command": "side_bar_open_in_browser", "args": { "paths": [], "type":"production" } },
 	{ "keys": ["ctrl+alt+f"], "command": "side_bar_find_files_path_containing" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,13 +1,6 @@
 [
-	{ "keys": ["ctrl+t"], "command": "side_bar_new_file2" },
-	{ "keys": ["f12"],
-		"command": "side_bar_open_in_browser" ,
-    "args":{"paths":[], "type":"testing"}
-  },
-	{ "keys": ["alt+f12"],
-		"command": "side_bar_open_in_browser",
-		"args":{"paths":[], "type":"production"}
-	},
-	{ "keys": ["f2"], "command": "side_bar_rename" },
+	{ "keys": ["f12"], "command": "side_bar_open_in_browser", "args": { "paths": [], "type":"testing" } },
+
+	{ "keys": ["alt+f12"], "command": "side_bar_open_in_browser", "args": { "paths": [], "type":"production" } },
 	{ "keys": ["ctrl+alt+f"], "command": "side_bar_find_files_path_containing" }
 ]


### PR DESCRIPTION
... and reformatted the JSON to match the formatting of Sublime's keymap files.

I removed both the `F2` (`side_bar_rename`) and the `ctrl+t` (`side_bar_new_file2`) shortcut.

This addresses #63.
