### PR TITLE
Google chrome not found due to non-standard (corporate) HOMEPATH setting

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -1288,6 +1288,7 @@ class SideBarOpenInBrowserCommand(sublime_plugin.WindowCommand):
 					'%HOMEPATH%\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe'
 
 					,reg_value+'\\Chrome\\Application\\chrome.exe'
+					,reg_value+'\\Google\\Chrome\\Application\\chrome.exe'
 					,'%HOMEPATH%\\Google\\Chrome\\Application\\chrome.exe'
 					,'%PROGRAMFILES%\\Google\\Chrome\\Application\\chrome.exe'
 					,'%PROGRAMFILES(X86)%\\Google\\Chrome\\Application\\chrome.exe'


### PR DESCRIPTION
Added additional path for Chrome browser on windows.
My particular configuration could not find chrome in any of the existing paths.
