### PR TITLE
Add correct Chromium run command for Ubuntu

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -1365,6 +1365,8 @@ class SideBarOpenInBrowserCommand(sublime_plugin.WindowCommand):
 				items.extend([
 					'/usr/bin/chromium'
 					,'chromium'
+					,'/usr/bin/chromium-browser'
+					,'chromium-browser'
 				])
 				commands = ['-new-tab', url]
 		elif browser == 'firefox':


### PR DESCRIPTION
In Ubuntu correct command for Chromium isn't "chromium", but "chromium-browser". Add this command to list of commands.
