### PR TITLE
fixed reveal for file with spaces in the name on Windows

### DIFF
--- a/sidebar/SideBarItem.py
+++ b/sidebar/SideBarItem.py
@@ -219,7 +219,7 @@ class SideBarItem:
 		return 'data:'+self.mime()+';base64,'+(file(self.path(), "rb").read().encode("base64").replace('\n', ''))
 
 	def reveal(self):
-		sublime.active_window().run_command("open_dir", {"dir": self.dirname(), "file": self.name()} )
+		sublime.active_window().run_command("open_dir", {"dir": self.dirname(), "file": '\"' + self.name() + '\"'} )
 
 	def write(self, content):
 		file(self.path(), 'w+').write(content)


### PR DESCRIPTION
If a file name in Windows has spaces in it, reveal just opens the directory in Windows Explorer without selecting the file.  The file needs quotes around it so Windows Explorer will select the file. I don't know how this affects Mac OS or Linux.
