### PR TITLE
Added command for refreshing the sidebar

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -80,5 +80,9 @@
         "caption": "File: Open In Browser - Production Server",
         "command": "side_bar_open_in_browser",
         "args":{"paths":[], "type":"production"}
+    },
+    {
+        "caption": "Side Bar: Refresh",
+        "command": "refresh_folder_list"
     }
 ]


### PR DESCRIPTION
On occasion, unrelated to SideBarEnhancements, the side bar does not automatically refresh. To solve this, I have chosen to add a command to SideBarEnhancements rather than create a separate plugin. In this PR:
- Add "Side Bar: Refresh" command which triggers Sublime's built-in `refresh_folder_list` command
