### PR TITLE
correctly open folders in a new window on mac os x

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -1451,7 +1451,15 @@ class SideBarOpenInNewWindowCommand(sublime_plugin.WindowCommand):
 	def run(self, paths = []):
 		import subprocess
 		items = []
-		items.append(sublime.executable_path())
+
+		executable_path = sublime.executable_path()
+
+		if sublime.platform() == 'osx':
+			app_path = executable_path[:executable_path.rfind(".app/")+5]
+			executable_path = app_path+"Contents/SharedSupport/bin/subl"
+
+		items.append(executable_path)
+
 		for item in SideBarSelection(paths).getSelectedItems():
 			items.append(item.forCwdSystemPath())
 			items.append(item.path())


### PR DESCRIPTION
this fixes #143 where "open in new window" would open new windows in a new app instance.
with this fix new windows will be opened in the running app instance.
