### PR TITLE
blacklist for auto adding folders

### DIFF
--- a/Side Bar.sublime-settings
+++ b/Side Bar.sublime-settings
@@ -14,6 +14,10 @@
 
 	"auto_add_folders_for_opened_files_when_project_is_empty": true,
 	"auto_add_folders_for_opened_files": false,
+	"blacklist_for_auto_add_folders_for_opened_files": [
+		"~",
+		"/"
+	],
 
 	"disabled_menuitem_edit": false,
 	"disabled_menuitem_open_run": false,

--- a/SideBar.py
+++ b/SideBar.py
@@ -1659,6 +1659,9 @@ class SideBarAutoAddFoldersForOpenedFiles(sublime_plugin.EventListener):
 		if not f or view.settings().has('SideBarAutoAddFoldersForOpenedFiles'):
 			return
 		path = os.path.dirname(f)
+		blacklist = s.get('blacklist_for_auto_add_folders_for_opened_files', [])
+		if path in [os.path.expanduser(d) for d in blacklist]:
+			return
 		if s.get('auto_add_folders_for_opened_files_when_project_is_empty') \
 				and not SideBarProject().hasDirectories():
 			if path and os.path.exists(path):
@@ -1671,5 +1674,3 @@ class SideBarAutoAddFoldersForOpenedFiles(sublime_plugin.EventListener):
 				SideBarProject().add(path)
 				view.settings().set('SideBarAutoAddFoldersForOpenedFiles', 1)
 				view.run_command('reveal_in_side_bar')
-
-


### PR DESCRIPTION
This is an attempt to solve the issue [here](https://github.com/titoBouzout/SideBarEnhancements/pull/191#issuecomment-46390543). 
`blacklist_for_auto_add_folders_for_opened_files` may not be good name, I cannot think of any for the moment. And I am not sure about Windows's compartibility.
