### PR TITLE
remove "auto_add_folders" functionality

### DIFF
--- a/Side Bar.sublime-settings
+++ b/Side Bar.sublime-settings
@@ -12,13 +12,6 @@
 
 	"new_files_relative_to_project_root": false,
 
-	"auto_add_folders_for_opened_files_when_project_is_empty": true,
-	"auto_add_folders_for_opened_files": false,
-	"blacklist_for_auto_add_folders_for_opened_files": [
-		"~",
-		"/"
-	],
-
 	"disabled_menuitem_edit": false,
 	"disabled_menuitem_open_run": false,
 	"disabled_menuitem_open_in_browser": false,

--- a/SideBar.py
+++ b/SideBar.py
@@ -1652,25 +1652,3 @@ class SideBarOpenWithFinderCommand(sublime_plugin.WindowCommand):
 
 	def is_visible(self, paths =[]):
 		return sublime.platform() == 'osx'
-
-class SideBarAutoAddFoldersForOpenedFiles(sublime_plugin.EventListener):
-	def on_activated(self, view):
-		f = view.file_name()
-		if not f or view.settings().has('SideBarAutoAddFoldersForOpenedFiles'):
-			return
-		path = os.path.dirname(f)
-		blacklist = s.get('blacklist_for_auto_add_folders_for_opened_files', [])
-		if path in [os.path.expanduser(d) for d in blacklist]:
-			return
-		if s.get('auto_add_folders_for_opened_files_when_project_is_empty') \
-				and not SideBarProject().hasDirectories():
-			if path and os.path.exists(path):
-				SideBarProject().add(path)
-				view.settings().set('SideBarAutoAddFoldersForOpenedFiles', 1)
-				view.run_command('reveal_in_side_bar')
-		elif s.get('auto_add_folders_for_opened_files') \
-				and not SideBarSelection([path]).hasItemsUnderProject():
-			if path and os.path.exists(path):
-				SideBarProject().add(path)
-				view.settings().set('SideBarAutoAddFoldersForOpenedFiles', 1)
-				view.run_command('reveal_in_side_bar')


### PR DESCRIPTION
I am submitting the PR to remove "auto_add_folders" functionality" with respect to the discussion [here](https://github.com/titoBouzout/SideBarEnhancements/pull/194) and [the PR](https://github.com/SublimeText/SideBarFolders/pull/8) for `SideBarFolders`.
