### PR TITLE
Fix encoding error when clicking on a file.

### DIFF
--- a/sidebar/SideBarItem.py
+++ b/sidebar/SideBarItem.py
@@ -215,7 +215,7 @@ class SideBarItem:
 		return self.isDirectory() == False
 
 	def contentUTF8(self):
-		return open(self.path(), 'r', newline='').read()
+		return open(self.path(), 'r', newline='', encoding='utf-8').read()
 
 	def contentBinary(self):
 		return open(self.path(), "rb").read()


### PR DESCRIPTION
Mac OS X 10.9, ST 3062.

Currently, almost every click on a file generates a UnicodeDecodeError, which isn't surprising since no encoding was passed to open. This commit fixes that.
