### PR TITLE
Add option to disable prompt for deletion when trash is unavailable.

### DIFF
--- a/Side Bar.sublime-settings
+++ b/Side Bar.sublime-settings
@@ -10,6 +10,8 @@
 
 	"confirm_before_deleting": true,
 
+	"confirm_before_permanently_deleting": true,
+
 	"new_files_relative_to_project_root": false,
 
 	"disabled_menuitem_edit": false,

--- a/SideBar.py
+++ b/SideBar.py
@@ -1298,7 +1298,8 @@ class SideBarDeleteCommand(sublime_plugin.WindowCommand):
 					send2trash(item.path())
 			SideBarProject().refresh();
 		except:
-			if sublime.ok_cancel_dialog('There is no trash bin, permanently delete?', 'Yes, Permanent Deletion'):
+			should_confirm = s.get('confirm_before_permanently_deleting', True)
+			if not should_confirm or sublime.ok_cancel_dialog('There is no trash bin, permanently delete?', 'Yes, Permanent Deletion'):
 				for item in SideBarSelection(paths).getSelectedItemsWithoutChildItems():
 					if s.get('close_affected_buffers_when_deleting_even_if_dirty', False):
 						item.closeViews()


### PR DESCRIPTION
Fixes #278.

Option: confirm_before_permanently_deleting
Default: True

This is one possible fix as discussed – an alternative would be disabling the dialog when existing option `disable_send_to_trash` is true. That would avoid adding a new option, but might be less obvious to new users (and would cause side effects – permanent deletion when trash _is_ available – for users who work in multiple environments or on network drives).
