### PR TITLE
Add support for custom locale in modified time

### DIFF
--- a/Side Bar.sublime-settings
+++ b/Side Bar.sublime-settings
@@ -1,6 +1,7 @@
 {
 	"statusbar_modified_time": false,
 	"statusbar_modified_time_format": "%A %b %d %H:%M:%S %Y",
+	"statusbar_modified_time": "C",
 
 	"statusbar_file_size": false,
 

--- a/SideBar.py
+++ b/SideBar.py
@@ -5,6 +5,8 @@ import os, shutil
 import threading, time
 import re
 
+import locale
+
 from .edit.Edit import Edit as Edit
 from .hurry.filesize import size as hurry_size
 
@@ -1889,6 +1891,7 @@ class SideBarStatusBarModifiedTime(sublime_plugin.EventListener):
 	def on_activated(self, v):
 		if v.file_name() and s.get('statusbar_modified_time', False):
 			try:
+				locale.setlocale(locale.LC_TIME, s.get('statusbar_modified_time_locale', 'C'))
 				self.show(v, os.path.getmtime(v.file_name()))
 			except:
 				pass

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ### In other languages
 
-Japanese - <http://taamemo.blogspot.jp/2012/10/sublime-text-2-sidebarenhancements.html?m=1>  
+Japanese - <http://taamemo.blogspot.jp/2012/10/sublime-text-2-sidebarenhancements.html?m=1>
 Russian - <https://www.youtube.com/watch?v=8I0dJTd58kI&feature=youtu.be&a>
 
 ## Description
@@ -217,12 +217,17 @@ Q: Can the package stop "show preview in a **right** click to a file".
 -   Todd Wolfson
 -   Tyler Thrailkill
 -   Yaroslav Admin
+-   Aleksandar Urosevic
 
 ## TODO
 
 <https://github.com/titoBouzout/SideBarEnhancements/issues/223>
 
 ## Change Log
+
+Update 2.151010
+
+-   add option "statusbar_modified_time_locale" to avoid broken locales on Windows
 
 Update 2.010905
 


### PR DESCRIPTION
As reported on ST forum topic [SideBar Enhanc.. (Clipboard, Open With., Reload renamed)](http://www.sublimetext.com/forum/viewtopic.php?f=5&t=3331&p=72648#p72648) I experienced issue with Serbian Cyrillic locale on Windows 10 - weekday and month name has been printed as question marks instead readable Cyrillic text in ST status-bar.

After some research, I decided to add new option to override default system locale in SideBarEnhancements option to print modified time in status-bar.

So, this pull-request adds support for custom locale of date/time with option 'statusbar_modified_time_locale'

Example for user's settings SideBar.sublime-settings file:

```
{ "statusbar_modified_time_locale": "Serbian (Latin)_Serbia", }
```

Cheers
