### PR TITLE
Update OpenWithListener to pass args to SideBarFilesOpenWithCommand

### DIFF
--- a/SideBar.py
+++ b/SideBar.py
@@ -72,7 +72,7 @@ class OpenWithListener(sublime_plugin.EventListener):
 				for item in settings[0]['children']:
 					try:
 						if item['open_automatically'] and selection.hasFilesWithExtension(item['args']['extensions']):
-							SideBarFilesOpenWithCommand(Window()).run([view.file_name()], item['args']['application'], item['args']['extensions'])
+							SideBarFilesOpenWithCommand(Window()).run([view.file_name()], item['args']['application'], item['args']['extensions'], item['args']['args'])
 							view.window().run_command('close')
 							break
 					except:


### PR DESCRIPTION
It seems like the 'args' option for the open-with commands was being ignored? I think this should fix that.