### PR TITLE
adding relative path menu

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -59,6 +59,10 @@
 		"caption": "File: Copy Path",
 		"command": "side_bar_copy_path"
     },
+    {
+		"caption": "File: Copy Relative Path",
+		"command": "side_bar_copy_relative_path"
+    },
 	{
 		"caption": "File: Copy Path Quoted",
 		"command": "side_bar_copy_path_quoted"

--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -347,6 +347,14 @@
 		}
 	},
 	{
+		"caption": "Copy Relative Path",
+		"id": "side-bar-clip-copy-relative-path",
+		"command": "side_bar_copy_relative_path",
+		"args": {
+			"paths": []
+		}
+	},
+	{
 		"caption": "Copy Dir Path",
 		"id": "side-bar-clip-copy-dir-path",
 		"command": "side_bar_copy_dir_path",

--- a/SideBar.py
+++ b/SideBar.py
@@ -778,6 +778,32 @@ class SideBarCopyPathCommand(sublime_plugin.WindowCommand):
 	def is_enabled(self, paths = []):
 		return CACHED_SELECTION(paths).len() > 0
 
+class SideBarCopyRelativePathCommand(sublime_plugin.WindowCommand):
+	def run(self, paths = []):
+		items = []
+		for item in SideBarSelection(paths).getSelectedItems():
+			items.append(item.path())
+
+		sublime.active_window().run_command("next_view_in_stack")
+		
+		originPath = sublime.active_window().active_view().file_name()
+
+		temp = []
+		for index in range(len(items)):
+			if(not os.path.samefile(items[index], originPath)):
+				temp.append(os.path.join(".", os.path.relpath(items[index], os.path.dirname(originPath))))
+		items = temp
+
+		if len(items) > 0:
+			sublime.set_clipboard("\n".join(items));
+			if len(items) > 1 :
+				sublime.status_message("Items copied")
+			else :
+				sublime.status_message("Item copied")
+
+	def is_enabled(self, paths = []):
+		return CACHED_SELECTION(paths).len() > 0
+
 class SideBarCopyPathQuotedCommand(sublime_plugin.WindowCommand):
 	def run(self, paths = []):
 		items = []


### PR DESCRIPTION
Adds a "Copy Relative Path" option in the sidebar contextual menu, which will copy relative paths toward selected files (from previously focused file) to the clipboard.
Whished it could be done by drag&dropping, but cannot find a solution.
Tested on windows 10, st3 build 3143