### PR TITLE
Allow arguments to be passed to command

### DIFF
--- a/SideBarAPI.py
+++ b/SideBarAPI.py
@@ -518,8 +518,10 @@ class SideBarItem:
                 )
             elif sublime.platform() == "windows":
                 if command:
+                    command = [command] + ["."]
+                    flat_command = [item for sublist in command for item in sublist]
                     subprocess.Popen(
-                        [command, "."], cwd=self.forCwdSystemPath(), shell=True
+                        flat_command, cwd=self.forCwdSystemPath(), shell=True
                     )
                 elif use_powershell:
                     try:


### PR DESCRIPTION
With the previous implementation of SideBarItem.open, if the command in the user setting had spaces, it would not work properly.
With this new implementation, command can be a string or a list, in order to set arguments for the command. 
(in my case I needed it because Windows Terminal is opened with the command "wt -d <DIRNAME>"