### PR TITLE
send2thrash: Fix deletion info on Linux

### DIFF
--- a/send2trash/plat_other.py
+++ b/send2trash/plat_other.py
@@ -74,13 +74,14 @@ def trash_move(src, dst, topdir=None):
 
     check_create(filespath)
     check_create(infopath)
+    f = open(op.join(infopath, destname + INFO_SUFFIX), 'w')
+    f.write(info_for(src, topdir))
+    f.close()
+
     try:
         os.rename(src, op.join(filespath, destname))
     except:
         shutil.move(src, op.join(filespath, destname))
-    f = open(op.join(infopath, destname + INFO_SUFFIX), 'w')
-    f.write(info_for(src, topdir))
-    f.close()
 
 def find_mount_point(path):
     # Even if something's wrong, "/" is a mount point, so the loop will exit.


### PR DESCRIPTION
The file needs to be moved after metadata are in place, otherwise Nautilus will not associate them with the file.

This was already fixed upstream: https://github.com/arsenetar/send2trash/commit/20bbab0b4c449c10d21b4388675f2bec775f4288