### PR TITLE
Use xdg-open instead of gnome-open.

### DIFF
--- a/desktop/__init__.py
+++ b/desktop/__init__.py
@@ -260,7 +260,7 @@ def open(url, desktop=None, wait=0):
         cmd = ["kfmclient", "exec", url]
 
     elif desktop_in_use == "GNOME":
-        cmd = ["gnome-open", url]
+        cmd = ["xdg-open", url]
 
     elif desktop_in_use == "XFCE":
         cmd = ["exo-open", url]


### PR DESCRIPTION
gnome-open has been deprecated for many GNOME-based systems: https://askubuntu.com/questions/1046400/what-should-be-used-instead-of-the-deprecated-gnome-open-in-ubuntu-18-04

Use xdg-open instead.