### PR TITLE
Add a command to copy path as a raw Python string

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -52,6 +52,10 @@
 		"command": "side_bar_copy_path_quoted"
 	},
 	{
+		"caption": "File: Copy Path Quoted as R\"Raw Python\"",
+		"command": "side_bar_copy_path_quoted_py"
+	},
+	{
 		"caption": "File: Copy Path (Windows)",
 		"command": "side_bar_copy_path_absolute_from_project_encoded_windows"
 	},

--- a/SideBar.py
+++ b/SideBar.py
@@ -1378,6 +1378,22 @@ class side_bar_copy_path_quoted(sublime_plugin.WindowCommand):
     def is_enabled(self, paths=[]):
         return CACHED_SELECTION(paths).len() > 0
 
+class side_bar_copy_path_quoted_py(sublime_plugin.WindowCommand):
+    def run(self, paths=[]):
+        items = []
+        for item in SideBarSelection(paths).getSelectedItems():
+            items.append('R"' + item.path().rstrip("\\") + '"')
+
+        if     len(items) > 0:
+            sublime.set_clipboard("\n".join(items))
+            if len(items) > 1:
+                sublime.status_message("Items copied")
+            else:
+                sublime.status_message("Item copied")
+
+    def is_enabled(self, paths=[]):
+        return CACHED_SELECTION(paths).len() > 0
+
 
 class SideBarCopyDirPathCommand(sublime_plugin.WindowCommand):
     def run(self, paths=[]):


### PR DESCRIPTION
Helpful for pasting paths in python-based shells
(strips last `\` to avoid invalid strings)