### PR TITLE
feat: add copy name without extension command

### DIFF
--- a/Side Bar.sublime-menu
+++ b/Side Bar.sublime-menu
@@ -84,6 +84,11 @@
 		"args": { "paths": [] }
 	},
 	{
+		"caption": "Copy Name Without Extension",
+		"command": "side_bar_copy_name_without_extension",
+		"args": { "paths": [] }
+	},
+	{
 		"caption": "Copy Path",
 		"id": "side-bar-clip-copy-path",
 		"command": "side_bar_copy_path_relative_from_project_encoded",
@@ -110,14 +115,12 @@
 		"args": { "paths": [] }
 	},
 	{ "caption": "-", "id": "side-bar-duplicate-separator" },
-
 	{
 		"caption": "Rename…",
 		"id": "side-bar-rename",
 		"command": "side_bar_rename",
 		"args": { "paths": [] }
 	},
-
 	{
 		"caption": "Move…",
 		"id": "side-bar-move",
@@ -131,7 +134,6 @@
 		"args": { "paths": [] }
 	},
 	{ "caption": "-", "id": "side-bar-rename-move-separator" },
-
 	{
 		"caption": "Delete",
 		"id": "side-bar-delete",

--- a/SideBar.py
+++ b/SideBar.py
@@ -701,6 +701,26 @@ class SideBarCopyNameCommand(sublime_plugin.WindowCommand):
         return CACHED_SELECTION(paths).len() > 0
 
 
+class SideBarCopyNameWithoutExtensionCommand(sublime_plugin.WindowCommand):
+    def run(self, paths=[]):
+        import os
+        items = []
+        for item in SideBarSelection(paths).getSelectedItems():
+            # Dosyanın ismini ve uzantısını ayırıp sadece ismi alıyoruz (0. indeks)
+            name_without_ext = os.path.splitext(item.name())[0]
+            items.append(name_without_ext)
+        
+        if len(items) > 0:
+            sublime.set_clipboard('\n'.join(items))
+            if len(items) > 1:
+                sublime.status_message("Items copied")
+            else:
+                sublime.status_message("Item copied")
+
+    def is_enabled(self, paths=[]):
+        return CACHED_SELECTION(paths).len() > 0
+
+
 class SideBarCopyNameEncodedCommand(sublime_plugin.WindowCommand):
     def run(self, paths=[]):
         items = []


### PR DESCRIPTION
Hi,

I have added a new feature that allows copying the filename without its extension. This is highly requested and very useful when importing modules or components where the file extension is not needed.

Changes made:
- Added "Copy Name Without Extension" to `Side Bar.sublime-menu`.
- Added `SideBarCopyNameWithoutExtensionCommand` class in `SideBar.py` to handle the splitting and clipboard logic.

Let me know if any changes are required.